### PR TITLE
Fixes #4 show html feeds before xml feeds

### DIFF
--- a/woodwind/views.py
+++ b/woodwind/views.py
@@ -217,7 +217,7 @@ def find_possible_feeds(origin):
 
         hfeed = mf2util.interpret_feed(mf2py.parse(doc=resp.text), origin)
         if hfeed.get('entries'):
-            feeds.append({
+            feeds.insert(0,{
                 'origin': origin,
                 'feed': origin,
                 'type': 'html',


### PR DESCRIPTION
A very simple fix, just insert html feeds at position 0 instead of
appending them to the list.  This ensures that html feeds are always
listed first
