### PR TITLE
default the collapsed state to open for posts

### DIFF
--- a/woodwind/templates/_entry.jinja2
+++ b/woodwind/templates/_entry.jinja2
@@ -28,7 +28,7 @@
 {% endfor %}
 
 <article>
-  <details><summary><header>
+  <details open><summary><header>
     {% if entry.author_photo %}
       <img src="{{entry.author_photo|proxy_image}}"/>
     {% endif %}
@@ -71,7 +71,6 @@
     </div>
   {% endif %}
 
- </details>
   <footer>
     {% set location = entry.get_property('location') %}
     {% if location and 'name' in location %}
@@ -98,4 +97,5 @@
       {% include '_reply.jinja2' with context %}
     </div>
   </footer>
+ </details>
 </article>

--- a/woodwind/templates/subscriptions.jinja2
+++ b/woodwind/templates/subscriptions.jinja2
@@ -48,13 +48,6 @@
         <button type="submit">Save Edits</button> <span class="save-status"></span>
       </form>
 
-
-      <div>
-        <a target="_blank" href="{{ url_for('.index', subscription=s.id) }}">View Posts</a>
-        <br/>
-        <a class="show-details" data-target="details-{{loop.index}}" href="#">Show Details</a>
-      </div>
-
       <div class="feed-details" id="details-{{loop.index}}">
         <details><summary><strong>Details</strong></summary>
         <ul>
@@ -80,6 +73,7 @@
         <input type="hidden" name="id" value="{{ s.id }}"/>
         <button type="submit">Unsubscribe</button> <span class="unsubscribe-status"></span>
       </form>
+      <a target="_blank" href="{{ url_for('.index', subscription=s.id) }}">View Posts</a>
 
 
     </article>


### PR DESCRIPTION
This still makes it easy to hide long posts that fill up the feed view, without having to expand all note-type posts. Now it also hides the reply buttons.
Also, small change to subscriptions view to show the 'view posts' link in collapsed state
