### PR TITLE
Swap indiewebcamp.com references for indieweb.org

### DIFF
--- a/frontend/indieconfig.js
+++ b/frontend/indieconfig.js
@@ -5,7 +5,7 @@ window.loadIndieConfig = (function () {
   // Indie-Config Loading script
   // by Pelle Wessman, voxpelli.com
   // MIT-licensed
-  // http://indiewebcamp.com/indie-config
+  // https://indieweb.org/indie-config
 
   var config, configFrame, configTimeout,
     callbacks = [],

--- a/setup.py
+++ b/setup.py
@@ -7,5 +7,5 @@ setup(name='Woodwind',
       description='Stream-style indieweb reader',
       author='Kyle Mahan',
       author_email='kyle@kylewm.com',
-      url='https://indiewebcamp.com/Woodwind',
+      url='https://indieweb.org/Woodwind',
       packages=['woodwind'])

--- a/woodwind/static/indieconfig.js
+++ b/woodwind/static/indieconfig.js
@@ -5,7 +5,7 @@ window.loadIndieConfig = (function () {
   // Indie-Config Loading script
   // by Pelle Wessman, voxpelli.com
   // MIT-licensed
-  // http://indiewebcamp.com/indie-config
+  // https://indieweb.org/indie-config
 
   var config, configFrame, configTimeout,
     callbacks = [],

--- a/woodwind/templates/base.jinja2
+++ b/woodwind/templates/base.jinja2
@@ -10,7 +10,7 @@
 
   <link rel="stylesheet" href="{{ url_for('static', filename='style.css', version='2016-03-08') }}"/>
   <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css"/>
-  
+
   <link rel="manifest" href="/manifest.json"/>
 
   <script src="/node_modules/jquery/dist/jquery.js"></script>
@@ -62,7 +62,7 @@
           <input type="hidden" name="next" placeholder="{{ request.path }}" />
           <button style="text-align: right;" type="submit">Login</button>
         </form>
-        Your Woodwind account is tied to your personal domain name. Check out IndieWebCamp's <a href="http://indiewebcamp.com/Getting_Started" target="_blank">Getting Started</a> page for details.
+        Your Woodwind account is tied to your personal domain name. Check out the IndieWeb's <a href="https://indieweb.org/Getting_Started" target="_blank">Getting Started</a> page for details.
       {% endif %}
 
     {% endblock login %}
@@ -77,7 +77,7 @@
   {% block foot %}{% endblock %}
 
   <div class="footer">
-    Woodwind is <a href="https://github.com/kylewm/woodwind">on GitHub</a>. Have any problems? File an issue or come chat in <code>#indiewebcamp</code> on Freenode IRC.
+    Woodwind is <a href="https://github.com/kylewm/woodwind">on GitHub</a>. Have any problems? File an issue or come chat in <code>#indieweb</code> on Freenode IRC.
   </div>
 
   <script>

--- a/woodwind/templates/settings.jinja2
+++ b/woodwind/templates/settings.jinja2
@@ -7,12 +7,12 @@
       <p>
         <input type="radio" id="reply-method-micropub" name="reply-method" value="micropub" {% if reply_method == 'micropub' %}checked{% endif %}/>
         <label for="reply-method-micropub">Micropub.</label>
-        Each post will have Like, Repost, and Reply buttons that will post content to your site directly via micropub. See <a href="https://indiewebcamp.com/Micropub">Micropub</a> for details.
+        Each post will have Like, Repost, and Reply buttons that will post content to your site directly via micropub. See <a href="https://indieweb.org/Micropub">Micropub</a> for details.
       </p>
       <p>
         <input type="radio" id="reply-method-indie-config" name="reply-method" value="indie-config" {% if reply_method == 'indie-config' %}checked{% endif %}/>
         <label for="reply-method-indie-config">Indie-config.</label>
-        Clicking an indie-action link will invoke your <code>web+action</code> handler if registered. See <a href="https://indiewebcamp.com/indie-config">indie-config</a> for details.
+        Clicking an indie-action link will invoke your <code>web+action</code> handler if registered. See <a href="https://indieweb.org/indie-config">indie-config</a> for details.
       </p>
       <p>
         <input type="radio" id="reply-method-action-urls" name="reply-method" value="action-urls" {% if reply_method == 'action-urls' %}checked{% endif %}/>

--- a/woodwind/templates/settings_indie_config.jinja2
+++ b/woodwind/templates/settings_indie_config.jinja2
@@ -5,7 +5,7 @@
       <!-- reply via indie-config -->
       <h2>Indie-Config</h2>
       <p>
-        Clicking an indie-action link will invoke your <code>web+action</code> handler if registered. See <a href="https://indiewebcamp.com/indie-config">indie-config</a> for details.
+        Clicking an indie-action link will invoke your <code>web+action</code> handler if registered. See <a href="https://indieweb.org/indie-config">indie-config</a> for details.
       </p>
       {% set selectedActions = settings.get('indie-config-actions', []) %}
 

--- a/woodwind/templates/settings_micropub.jinja2
+++ b/woodwind/templates/settings_micropub.jinja2
@@ -4,7 +4,7 @@
     <!-- reply via micropub -->
     <h2>Micropub</h2>
     <p>
-      Each post will have Like, Repost, and Reply buttons that will post content to your site directly via micropub. See <a href="https://indiewebcamp.com/Micropub">Micropub</a> for details.
+      Each post will have Like, Repost, and Reply buttons that will post content to your site directly via micropub. See <a href="https://indieweb.org/Micropub">Micropub</a> for details.
     </p>
     <p>
       Configure micropub credentials.


### PR DESCRIPTION
Now that indiewebcamp.com has migrated to indieweb.org, change the URLs. Also change the referenced IRC channel from `#indiewebcamp` to `#indieweb`
