### PR TITLE
Add missing paren in views.py

### DIFF
--- a/woodwind/views.py
+++ b/woodwind/views.py
@@ -381,8 +381,7 @@ def update_micropub_syndicate_to():
         flask_login.current_user.set_setting('syndicate-to', syndicate_tos)
         db.session.commit()
     except ValueError as e:
-        flask.flash('Could not parse syndicate-to response: {}'.format(e)
-
+        flask.flash('Could not parse syndicate-to response: {}'.format(e))
 
 
 @views.route('/deauthorize')


### PR DESCRIPTION
When setting up my own instance of Woodwind from the master branch I was getting a syntax error from `woodwind/views.py`.

Tracked it down to this missing parenthesis.