### PR TITLE
Add OPML export of subscriptions

### DIFF
--- a/woodwind/templates/subscriptions.jinja2
+++ b/woodwind/templates/subscriptions.jinja2
@@ -19,6 +19,7 @@
 
     <form action="{{ url_for('.update_all') }}" method="POST">
       <button type="submit">Poll All</button>
+      <a href="{{ url_for('.subscriptions_opml')}}">Export as OPML</a>
     </form>
   </article>
 

--- a/woodwind/templates/subscriptions_opml.xml
+++ b/woodwind/templates/subscriptions_opml.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<opml version="2.0">
+  <body>
+    <outline text="Subscriptions" title="Woodwind">
+    {% for s in subscriptions %}
+      <outline xmlUrl="{{ s.feed.feed }}" />
+    {% endfor %}
+    </outline>
+  </body>
+</opml>


### PR DESCRIPTION
It's nice to be able to export all your subscriptions if you want to
move to a different reader. This patch adds a link to the subscription
page where one can download the subscription list as OPML which is
the standard way of importing/exporting between feed readers.